### PR TITLE
added null check in getting saml attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.onelogin</groupId>
   <artifactId>java-saml</artifactId>
-  <version>1.1.5</version>
+  <version>1.1.6</version>
   
   <properties>
     <slf4jVersion>1.7.12</slf4jVersion>

--- a/src/main/java/com/onelogin/saml/Response.java
+++ b/src/main/java/com/onelogin/saml/Response.java
@@ -267,7 +267,7 @@ public class Response {
     public String getAttribute(String name) {
         HashMap<String, ArrayList<String>> attributes = getAttributes();
 
-        if (!attributes.isEmpty()) {
+        if (attributes != null && !attributes.isEmpty()) {
             ArrayList<String> attrVal = attributes.get(name);
             return attrVal == null || attrVal.size() == 0 ? null : attrVal.get(0).toString();
         }


### PR DESCRIPTION
response.getAttribute() will throw `NullPointerException` if the attribute is not found in saml. 
this is a fix.